### PR TITLE
Enums: remove AdType, add RateType, name changes to EventType

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -64,7 +64,7 @@ export enum RateType {
   Flat = 1,
   CPM = 2,
   CPC = 3,
-  CPA_View = 4,
-  CPA_Click = 5,
-  CPA_ViewAndClick = 6,
+  CPAView = 4,
+  CPAClick = 5,
+  CPAViewAndClick = 6,
 }


### PR DESCRIPTION
@CrshOverride Per our conversation, I've done the following:

1) Removed the `AdType` enum.  My reasoning here is that Ad Type IDs are not an actual enumerated type but per-customer data like a `networkID` or a `siteID`.  As such, having an enum, even for the handful of "global" IDs is confusing and ultimately leads our developer users in the wrong direction.

2) Copied the `RateType` enum from the Java SDK over to the JS SDK.

3) Made a few changes to the names on the `EventType` enum.  The big change was adding the `Video` prefix to the many video events.  I also broke with the ordering convention you were using before (ordering the items by their integer value) in order to move a few `Comments*` events together.