### PR TITLE
[sc-22396] Add grossMerchandiseValue option to all events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8334,7 +8334,7 @@
         "json5": "^1.0.1",
         "micromatch": "^3.0.4",
         "mkdirp": "^0.5.1",
-        "node-forge": "0.10.0",
+        "node-forge": "^0.7.1",
         "node-libs-browser": "^2.0.0",
         "opn": "^5.1.0",
         "postcss": "^7.0.11",

--- a/src/client.ts
+++ b/src/client.ts
@@ -61,6 +61,7 @@ interface PixelFireOptions {
   revenueOverride?: number;
   additionalRevenue?: number;
   eventMultiplier?: number;
+  grossMerchandiseValue?: number;
 }
 
 interface AdditionalOptions {
@@ -293,6 +294,9 @@ class PixelClient {
     }
     if (params.eventMultiplier) {
       parsed.searchParams.append('eventMultiplier', params.eventMultiplier.toString());
+    }
+    if (params.grossMerchandiseValue) {
+      parsed.searchParams.append('gmv', params.grossMerchandiseValue.toString());
     }
 
     return parsed.href;


### PR DESCRIPTION
All event URLs may optionally include a `gmv=<value>` query parameter, where `<value>` is a number (integer or float). This change allows the user to do the following:

```javascript
client.pixels.fire({url: response.decisions.div0.events[0].url, grossMerchandiseValue: 123.45})
``` 