### PR TITLE
SC28364: Fix clone removal regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7757,6 +7757,8 @@
     },
     "node-forge": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -8402,6 +8404,8 @@
         },
         "node-forge": {
           "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
           "dev": true
         },
         "postcss": {

--- a/src/generated/runtime.ts
+++ b/src/generated/runtime.ts
@@ -101,7 +101,7 @@ export class BaseAPI {
             fetch: this.fetchApi,
             url,
             init,
-            response: response.clone(),
+            response: response,
           })) || response;
       }
     }


### PR DESCRIPTION
It looks like https://github.com/adzerk/adzerk-decision-sdk-js/commit/a58853ee6f40c34871c856b1dd7dcc9a81f1f07b accidentally got overwritten without being re-fixed during regeneration.

This PR re-removes `.clone` as it's broken for large responses and causes the SDK to fail silently.