### PR TITLE
fix(npmignore): ignore .husky + .parcel-cache

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -61,7 +61,9 @@ typings/
 .next
 
 .github
+.husky
 .cache
+.parcel-cache
 .vscode
 
 src


### PR DESCRIPTION
Avoids including the 4.28 MB `.parcel-cache` folder in the package, reducing its unpacked size by more than 90%: <img width="1206" alt="image" src="https://user-images.githubusercontent.com/495429/232526214-046f0a94-3b7e-4a26-b05d-97fe25a19e50.png">
