### PR TITLE
Don't send User-Agent for browser-based requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -336,8 +336,11 @@ class PixelClient {
 
     let headersbase = {
       'X-Adzerk-Sdk-Version': this._versionString,
-      'User-Agent': additionalOpts?.userAgent || 'OpenAPI-Generator/1.0/js',
     };
+    // Only add User-Agent if we're not in a browser
+    if (typeof window === 'undefined') {
+      headersbase['User-Agent'] = additionalOpts?.userAgent || 'OpenAPI-Generator/1.0/js';
+    }
     let headers = additionalOpts?.apiKey ?
       { ...headersbase, 'X-Kevel-ApiKey': additionalOpts.apiKey } :
       headersbase;

--- a/src/client.ts
+++ b/src/client.ts
@@ -334,7 +334,7 @@ class PixelClient {
   ): Promise<PixelFireResponse> {
     let logger = this._logger || defaultLogger;
 
-    let headersbase = {
+    let headersbase : Record<string, string> = {
       'X-Adzerk-Sdk-Version': this._versionString,
     };
     // Only add User-Agent if we're not in a browser


### PR DESCRIPTION
If the SDK is used from a browser, then sending the User-Agent header triggers a preflight request to the server and we don't specify that it is allowed. This PR only adds a User-Agent header if the SDK is being used outside of a browser.