### PR TITLE
PE-978: Upgrade Node.js to 24 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18, 20, 22 ]
+        node-version: [ 18, 20, 22, 24 ]
     steps:
 
     - name: Checkout Repository
@@ -35,7 +35,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Install npm-force-resolutions
       run: npm install -g npm-force-resolutions


### PR DESCRIPTION
## Summary

Upgrade Node.js version to 24 in GitHub Actions workflows as part of PE-978.

Node 20 reached EOL in April 2026. Node 22 is now in maintenance. Node 24 is the current Active LTS.

**Changed files:**
- `.github/workflows/nodejs.yml`

## Test plan

- [ ] Verify CI passes on this branch
- [ ] Confirm workflow steps using Node.js complete successfully
